### PR TITLE
Clean review rows with Early Access Review only, also clean short ones

### DIFF
--- a/dataIngestion/dataset_clean.py
+++ b/dataIngestion/dataset_clean.py
@@ -78,6 +78,10 @@ def stemming(text):
     stem = ' '.join(stemmed_word)
     return stem
 
+def remove_EAR(x):
+    """ Remove those review with 'Early Access Review' only """
+    cleaned_string = re.sub(r"earl[iy] access review", '', x)
+    return cleaned_string
 
 def cleaning(df, review):
     """ Main cleaning function that combining all """
@@ -87,9 +91,10 @@ def cleaning(df, review):
     df[review] = df[review].apply(remove_num)
     df[review] = df[review].apply(remove_symbols)
     df[review] = df[review].apply(remove_punctuation)
-    df[review] = df[review].apply(remove_stopword)
+    #df[review] = df[review].apply(remove_stopword)
+    #df[review] = df[review].apply(stemming)
+    df[review] = df[review].apply(remove_EAR)
     df[review] = df[review].apply(unify_whitespaces)
-    df[review] = df[review].apply(stemming)
 
 
 

--- a/dataIngestion/dataset_clean_example_main.py
+++ b/dataIngestion/dataset_clean_example_main.py
@@ -29,8 +29,17 @@ if __name__ == '__main__':
     review.review_text = review.review_text.astype('str')
 
     # word_cloud_show(review)
+    print("Shape before cleaning : " + str(review.shape))
 
     # Below code are to clean data.
-    nltk.download('stopwords')
+    #nltk.download('stopwords')
     cleaning(review, 'review_text')
+    # Drop the rows with too short review_text. Feel free to Change the minimum len, 1,  as you like.
+    review = review[review['review_text'].map(len) > 1]
+
+    # Print some samples
+    print("Shape after cleaning : " + str(review.shape))
     print(review[['review_text']].head(10))
+
+    print("Saving clean dataset to dataset.cleaned.csv")
+    review.to_csv('dataset.cleaned.csv')


### PR DESCRIPTION
   1. Comment out cleaning of stopwords and stemming.
   2. Add cleaning of those review_text with "Early Access Review" only.
   3. Remove short review with only 1 char and empty reviews
   4. Save cleaned dataset to "dataset.cleaned.csv", so you don't have to run clean each time.
   
