### PR TITLE
Download nltk stopwords just once

### DIFF
--- a/dataIngestion/dataset_clean.py
+++ b/dataIngestion/dataset_clean.py
@@ -1,9 +1,8 @@
 import pandas as pd
 import re
 import nltk
+import os
 
-from nltk import WordNetLemmatizer
-from nltk.stem import PorterStemmer
 from nltk.corpus import stopwords
 from nltk.stem import SnowballStemmer
 
@@ -58,14 +57,9 @@ def remove_punctuation(text):
     final = "".join(u for u in text if u not in ("?", ".", ";", ":", "!", '"', ','))
     return final
 
-
-stop = set(stopwords.words("english"))
-stemmer = PorterStemmer()
-lemma = WordNetLemmatizer()
-
-
 def remove_stopword(text):
     """ Remove stopwords """
+    stop = set(stopwords.words("english"))
     text = [word.lower() for word in text.split() if word.lower() not in stop]
     return " ".join(text)
 
@@ -85,6 +79,8 @@ def remove_EAR(x):
 
 def cleaning(df, review):
     """ Main cleaning function that combining all """
+    if not os.path.exists(os.path.expanduser('~/nltk_data')):
+        nltk.download('stopwords')
     df[review] = df[review].apply(clean_hyperlinks_and_markup)
     df[review] = df[review].apply(deEmojify)
     df[review] = df[review].str.lower()

--- a/dataIngestion/dataset_clean_example_main.py
+++ b/dataIngestion/dataset_clean_example_main.py
@@ -32,7 +32,6 @@ if __name__ == '__main__':
     print("Shape before cleaning : " + str(review.shape))
 
     # Below code are to clean data.
-    #nltk.download('stopwords')
     cleaning(review, 'review_text')
     # Drop the rows with too short review_text. Feel free to Change the minimum len, 1,  as you like.
     review = review[review['review_text'].map(len) > 1]

--- a/dataRanking/rank_dataset_example.py
+++ b/dataRanking/rank_dataset_example.py
@@ -17,7 +17,6 @@ if __name__ == '__main__':
     p = 0.02
     review = pandas.read_csv('../dataIngestion/dataset.csv', skiprows=lambda i: i > 0 and random.random() > p)
     review.review_text = review.review_text.astype('str')
-    nltk.download('stopwords')
     cleaning(review, 'review_text')
 
     # Get the query


### PR DESCRIPTION
Download stop words only when ~/nltk_data doesn't exists.   This is one-time download and cached, and not each time run.  This makes our program run faster.